### PR TITLE
Fix building error. Use interfaces for parameters

### DIFF
--- a/src/src/Events.cs
+++ b/src/src/Events.cs
@@ -217,7 +217,7 @@ namespace JulMar.Atapi
         /// <summary>
         /// The line that is ringing
         /// </summary>
-        public readonly TapiLine Line;
+        public readonly ITapiLine Line;
         /// <summary>
         /// The number of rings which have occurred.
         /// </summary>
@@ -230,7 +230,7 @@ namespace JulMar.Atapi
         /// <summary>
         /// Constructor
         /// </summary>
-        internal RingEventArgs(TapiLine line, int mode, int rcount)
+        internal RingEventArgs(ITapiLine line, int mode, int rcount)
         {
             Line = line;
             RingerStyle = mode;
@@ -266,12 +266,12 @@ namespace JulMar.Atapi
         /// <summary>
         /// The line which has changed.
         /// </summary>
-        public readonly TapiLine Line;
+        public readonly ITapiLine Line;
         /// <summary>
         /// The change(s) which have occurred.
         /// </summary>
         public readonly LineInfoChangeTypes Change;
-        internal LineInfoChangeEventArgs(TapiLine line, LineInfoChangeTypes change)
+        internal LineInfoChangeEventArgs(ITapiLine line, LineInfoChangeTypes change)
         {
             Line = line;
             Change = change;
@@ -331,11 +331,11 @@ namespace JulMar.Atapi
         /// <summary>
         /// The line associated with the Device Specific request
         /// </summary>
-        public readonly TapiLine Line;
+        public readonly ITapiLine Line;
         /// <summary>
         /// The call associated with the device specific request (may be null).
         /// </summary>
-        public readonly TapiCall Call;
+        public readonly ITapiCall Call;
         /// <summary>
         /// The phone associated with the device specific request (may be null).
         /// </summary>

--- a/src/src/Interfaces/ITapiAddress.cs
+++ b/src/src/Interfaces/ITapiAddress.cs
@@ -114,7 +114,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="requestedCallstates">Callstate desired</param>
         /// <returns>TapiCall array</returns>
-        TapiCall[] FindCallsByCallState(CallState requestedCallstates);
+        ITapiCall[] FindCallsByCallState(CallState requestedCallstates);
 
         /// <summary>
         /// This forwards calls destined for this address according to the specified forwarding instructions. 
@@ -124,7 +124,7 @@ namespace JulMar.Atapi
         /// <param name="forwardInstructions">The forwarding instructions to apply</param>
         /// <param name="numRingsNoAnswer">Number of rings before a call is considered a "no answer." If dwNumRingsNoAnswer is out of range, the actual value is set to the nearest value in the allowable range.</param>
         /// <param name="param">Optional call parameters - only used if a consultation call is returned; otherwise ignored.  May be null for default parameters</param>
-        TapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param);
+        ITapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param);
 
         /// <summary>
         /// This returns a device identifier for the specified device class associated with the call
@@ -138,7 +138,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="address">Number to dial</param>
         /// <returns>New <see>TapiCall</see> object.</returns>
-        TapiCall MakeCall(string address);
+        ITapiCall MakeCall(string address);
 
         /// <summary>
         /// Places a new call on the address
@@ -147,7 +147,7 @@ namespace JulMar.Atapi
         /// <param name="countryCode">Country code</param>
         /// <param name="param">Optional <see>MakeCallParams</see> to use while dialing</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        TapiCall MakeCall(string address, int countryCode, MakeCallParams param);
+        ITapiCall MakeCall(string address, int countryCode, MakeCallParams param);
 
         /// <summary>
         /// This picks up a call alerting at the specified destination address and returns a call handle for the picked-up call. 
@@ -157,7 +157,7 @@ namespace JulMar.Atapi
         /// <param name="alertingAddress">Address to retrieve call from</param>
         /// <param name="groupId">Optional group ID, can be null or empty</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        TapiCall Pickup(string alertingAddress, string groupId);
+        ITapiCall Pickup(string alertingAddress, string groupId);
 
         /// <summary>
         /// This method is used to establish a conference call
@@ -166,13 +166,13 @@ namespace JulMar.Atapi
         /// <param name="mcp">Call parameters for created consultation call</param>
         /// <param name="consultCall">Returning consultation call</param>
         /// <returns>Conference call</returns>
-        TapiCall SetupConference(int conferenceCount, MakeCallParams mcp, out TapiCall consultCall);
+        ITapiCall SetupConference(int conferenceCount, MakeCallParams mcp, out TapiCall consultCall);
 
         /// <summary>
         /// This retrieves a call off a parked address
         /// </summary>
         /// <param name="parkedAddress">Address to retrieve call from</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        TapiCall Unpark(string parkedAddress);
+        ITapiCall Unpark(string parkedAddress);
     }
 }

--- a/src/src/Interfaces/ITapiCall.cs
+++ b/src/src/Interfaces/ITapiCall.cs
@@ -859,5 +859,11 @@ namespace JulMar.Atapi
 		/// </summary>
 		void Unhold();
 
-	}
+        /// <summary>
+		/// IDisposable.Dispose implementation
+		/// </summary>
+        void Dispose();
+
+
+    }
 }

--- a/src/src/Interfaces/ITapiLine.cs
+++ b/src/src/Interfaces/ITapiLine.cs
@@ -11,7 +11,7 @@ namespace JulMar.Atapi
         /// <summary>
         /// The available addresses on this line.
         /// </summary>
-        TapiAddress[] Addresses { get; }
+        ITapiAddress[] Addresses { get; }
 
         /// <summary>
         /// Returns the <see cref="LineCapabilities"/> object for this line.
@@ -151,7 +151,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="number">DN to locate</param>
         /// <returns>TapiAddress or null if not found.</returns>
-        TapiAddress FindAddress(string number);
+        ITapiAddress FindAddress(string number);
 
         /// <summary>
         /// This forwards calls destined for all addresses on the specified line, according to the specified forwarding instructions. 
@@ -161,7 +161,7 @@ namespace JulMar.Atapi
         /// <param name="forwardInstructions">The forwarding instructions to apply</param>
         /// <param name="numRingsNoAnswer">Number of rings before a call is considered a "no answer." If dwNumRingsNoAnswer is out of range, the actual value is set to the nearest value in the allowable range.</param>
         /// <param name="param">Optional call parameters - only used if a consultation call is returned; otherwise ignored.  May be null for default parameters</param>
-        TapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param);
+        ITapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param);
 
         /// <summary>
         /// Returns the phone device associated with this line.
@@ -233,7 +233,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="address">Number to dial</param>
         /// <returns><see cref="TapiCall"/> object or null.</returns>
-        TapiCall MakeCall(string address);
+        ITapiCall MakeCall(string address);
 
         /// <summary>
         /// This places a call on the first available address of the line.
@@ -242,7 +242,7 @@ namespace JulMar.Atapi
         /// <param name="country"><see cref="Country"/> object (null for default).</param>
         /// <param name="param">Optional <see cref="MakeCallParams"/> to use when dialing.</param>
         /// <returns><see cref="TapiCall"/> object or null.</returns>
-        TapiCall MakeCall(string address, Country country, MakeCallParams param);
+        ITapiCall MakeCall(string address, Country country, MakeCallParams param);
 
         /// <summary>
         /// This opens the line in non-owner (monitor) mode so that new and existing calls can be viewed but not manipulated.

--- a/src/src/TapiAddress.cs
+++ b/src/src/TapiAddress.cs
@@ -615,7 +615,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="requestedCallstates">Callstate desired</param>
         /// <returns>TapiCall array</returns>
-        public TapiCall[] FindCallsByCallState(CallState requestedCallstates)
+        public ITapiCall[] FindCallsByCallState(CallState requestedCallstates)
         {
             var calls = new List<TapiCall>();
             lock (_calls)
@@ -750,7 +750,7 @@ namespace JulMar.Atapi
         /// <param name="forwardInstructions">The forwarding instructions to apply</param>
         /// <param name="numRingsNoAnswer">Number of rings before a call is considered a "no answer." If dwNumRingsNoAnswer is out of range, the actual value is set to the nearest value in the allowable range.</param>
         /// <param name="param">Optional call parameters - only used if a consultation call is returned; otherwise ignored.  May be null for default parameters</param>
-        public TapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param)
+        public ITapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param)
         {
             if (!Line.IsOpen)
                 throw new TapiException("Line is not open", NativeMethods.LINEERR_OPERATIONUNAVAIL);
@@ -824,7 +824,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="address">Number to dial</param>
         /// <returns>New <see>TapiCall</see> object.</returns>
-        public TapiCall MakeCall(string address)
+        public ITapiCall MakeCall(string address)
         {
             return MakeCall(address, 0, null);
         }
@@ -836,7 +836,7 @@ namespace JulMar.Atapi
         /// <param name="countryCode">Country code</param>
         /// <param name="param">Optional <see>MakeCallParams</see> to use while dialing</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        public TapiCall MakeCall(string address, int countryCode, MakeCallParams param)
+        public ITapiCall MakeCall(string address, int countryCode, MakeCallParams param)
         {
             if (!Line.IsOpen)
                 throw new TapiException("Line is not open", NativeMethods.LINEERR_OPERATIONUNAVAIL);
@@ -883,7 +883,7 @@ namespace JulMar.Atapi
         /// <param name="alertingAddress">Address to retrieve call from</param>
         /// <param name="groupId">Optional group ID, can be null or empty</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        public TapiCall Pickup(string alertingAddress, string groupId)
+        public ITapiCall Pickup(string alertingAddress, string groupId)
         {
             uint hCall;
             int rc = NativeMethods.linePickup(_lineOwner.Handle, _addressId, out hCall, alertingAddress, groupId);
@@ -914,7 +914,7 @@ namespace JulMar.Atapi
         /// <param name="mcp">Call parameters for created consultation call</param>
         /// <param name="consultCall">Returning consultation call</param>
         /// <returns>Conference call</returns>
-        public TapiCall SetupConference(int conferenceCount, MakeCallParams mcp, out TapiCall consultCall)
+        public ITapiCall SetupConference(int conferenceCount, MakeCallParams mcp, out TapiCall consultCall)
         {
             IntPtr lpCp = IntPtr.Zero;
             int callFlags = 0;
@@ -968,7 +968,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="parkedAddress">Address to retrieve call from</param>
         /// <returns>New <see cref="TapiCall"/> object.</returns>
-        public TapiCall Unpark(string parkedAddress)
+        public ITapiCall Unpark(string parkedAddress)
         {
             uint hCall;
             int rc = NativeMethods.lineUnpark(_lineOwner.Handle, _addressId, out hCall, parkedAddress);

--- a/src/src/TapiCall.cs
+++ b/src/src/TapiCall.cs
@@ -378,7 +378,7 @@ namespace JulMar.Atapi
 			GatherCallStatus();
 
 			int addrId = _lci.dwAddressID;
-			_addrOwner = lineOwner.Addresses[addrId];
+			_addrOwner = (TapiAddress)lineOwner.Addresses[addrId];
             _lineOwner = (TapiLine)_addrOwner.Line;
             Guid = Guid.NewGuid();
 		}

--- a/src/src/TapiLine.cs
+++ b/src/src/TapiLine.cs
@@ -500,9 +500,9 @@ namespace JulMar.Atapi
         readonly LINEDEVSTATUS _lds;
         readonly byte[] _rawBuffer;
 
-        internal LineStatus(TapiLine owner, LINEDEVSTATUS lds, byte[] buffer)
+        internal LineStatus(ITapiLine owner, LINEDEVSTATUS lds, byte[] buffer)
         {
-            _lineOwner = owner;
+            _lineOwner = (TapiLine)owner;
             _lds = lds;
             _rawBuffer = buffer;
         }
@@ -1007,7 +1007,7 @@ namespace JulMar.Atapi
         /// <summary>
         /// The available addresses on this line.
         /// </summary>
-        public TapiAddress[] Addresses
+        public ITapiAddress[] Addresses
         {
             get { return (TapiAddress[]) _addresses.Clone(); }
         }
@@ -1050,7 +1050,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="number">DN to locate</param>
         /// <returns>TapiAddress or null if not found.</returns>
-        public TapiAddress FindAddress(string number)
+        public ITapiAddress FindAddress(string number)
         {
             return _addresses.FirstOrDefault(addr => string.Compare(addr.Address, number, true, CultureInfo.InvariantCulture) == 0);
         }
@@ -1219,7 +1219,7 @@ namespace JulMar.Atapi
         /// </summary>
         /// <param name="address">Number to dial</param>
         /// <returns><see cref="TapiCall"/> object or null.</returns>
-        public TapiCall MakeCall(string address)
+        public ITapiCall MakeCall(string address)
         {
             return MakeCall(address, null, null);
         }
@@ -1231,7 +1231,7 @@ namespace JulMar.Atapi
         /// <param name="country"><see cref="Country"/> object (null for default).</param>
         /// <param name="param">Optional <see cref="MakeCallParams"/> to use when dialing.</param>
         /// <returns><see cref="TapiCall"/> object or null.</returns>
-        public TapiCall MakeCall(string address, Country country, MakeCallParams param)
+        public ITapiCall MakeCall(string address, Country country, MakeCallParams param)
         {
             return (from addr in Addresses 
                     where addr.Status.CanMakeCall 
@@ -1351,7 +1351,7 @@ namespace JulMar.Atapi
         /// <param name="forwardInstructions">The forwarding instructions to apply</param>
         /// <param name="numRingsNoAnswer">Number of rings before a call is considered a "no answer." If dwNumRingsNoAnswer is out of range, the actual value is set to the nearest value in the allowable range.</param>
         /// <param name="param">Optional call parameters - only used if a consultation call is returned; otherwise ignored.  May be null for default parameters</param>
-        public TapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param)
+        public ITapiCall Forward(ForwardInfo[] forwardInstructions, int numRingsNoAnswer, MakeCallParams param)
         {
             if (!IsOpen)
                 throw new TapiException("Line is not open", NativeMethods.LINEERR_OPERATIONUNAVAIL);

--- a/src/src/TapiManager.cs
+++ b/src/src/TapiManager.cs
@@ -544,7 +544,7 @@ namespace JulMar.Atapi
                     {
                         TapiCall call = TapiCall.FindCallByHandle(msg.hDevice);
                         if (call != null)
-                            call.Line.OnDeviceSpecific(call, msg.dwParam1, msg.dwParam2, msg.dwParam3);
+                            ((TapiLine)call.Line).OnDeviceSpecific(call, msg.dwParam1, msg.dwParam2, msg.dwParam3);
                         else
                             goto case TapiEvent.LINE_CLOSE;
                     }

--- a/src/src/TapiPhone.cs
+++ b/src/src/TapiPhone.cs
@@ -1650,7 +1650,7 @@ namespace JulMar.Atapi
         /// Returns the line device associated with this phone.
         /// </summary>
         /// <returns>TapiLine</returns>
-        public TapiLine GetAssociatedLine()
+        public ITapiLine GetAssociatedLine()
         {
             if (_mgr.Lines.Length > 0)
             {

--- a/src/test/Phone/ActiveCallForm.cs
+++ b/src/test/Phone/ActiveCallForm.cs
@@ -12,11 +12,11 @@ namespace Phone
 {
     public partial class ActiveCallForm : Form
     {
-        private TapiCall _call;
+        private ITapiCall _call;
 
-        public ActiveCallForm(TapiCall call)
+        public ActiveCallForm(ITapiCall call)
         {
-            TapiLine line = call.Line;
+            var line = call.Line;
 
             _call = call;
             line.CallInfoChanged += OnCallInfoChange;
@@ -121,7 +121,7 @@ namespace Phone
             SelectCallForm scf = new SelectCallForm(_call.Line);
             if (scf.ShowDialog() == DialogResult.OK)
             {
-                TapiCall otherCall = scf.SelectedCall;
+                var otherCall = scf.SelectedCall;
                 if (otherCall != null && otherCall != _call)
                 {
                     _call.SwapHold(otherCall);

--- a/src/test/Phone/MainForm.cs
+++ b/src/test/Phone/MainForm.cs
@@ -162,21 +162,21 @@ namespace Phone
 
         private void _btnMakeCall_Click(object sender, EventArgs e)
         {
-            TapiCall tc = CurrentAddress.MakeCall(_tbNumber.Text);
+            ITapiCall tc = CurrentAddress.MakeCall(_tbNumber.Text);
             ActiveCallForm acf = new ActiveCallForm(tc);
             acf.Show();
         }
 
         private void _btnPickup_Click(object sender, EventArgs e)
         {
-            TapiCall tc = CurrentAddress.Pickup(_tbNumber.Text, null);
+            ITapiCall tc = CurrentAddress.Pickup(_tbNumber.Text, null);
             ActiveCallForm acf = new ActiveCallForm(tc);
             acf.Show();
         }
 
         private void _btnUnpark_Click(object sender, EventArgs e)
         {
-            TapiCall tc = CurrentAddress.Unpark(_tbNumber.Text);
+            ITapiCall tc = CurrentAddress.Unpark(_tbNumber.Text);
             ActiveCallForm acf = new ActiveCallForm(tc);
             acf.Show();
         }

--- a/src/test/Phone/SelectCallForm.cs
+++ b/src/test/Phone/SelectCallForm.cs
@@ -11,10 +11,10 @@ namespace Phone
 {
     public partial class SelectCallForm : Form
     {
-        TapiLine _line;
+        ITapiLine _line;
         TapiCall _call;
 
-        public SelectCallForm(TapiLine line)
+        public SelectCallForm(ITapiLine line)
         {
             _line = line;
             InitializeComponent();


### PR DESCRIPTION
I change a few classes to use the interfaces as a parameter and as a return type.
I made a mistake trying to change as little as possible to not affect the library.

This PR fix #9 