### PR TITLE
Fix ForwardingInformation unmarshaling (TAPI <3.1)

### DIFF
--- a/src/src/TapiAddress.cs
+++ b/src/src/TapiAddress.cs
@@ -446,7 +446,7 @@ namespace JulMar.Atapi
                     for (int i = 0; i < _las.dwForwardNumEntries; i++)
                     {
                         var lfw = new LINEFORWARD();
-                        int size = Marshal.SizeOf(lfw);
+                        int size = _las.dwForwardSize;
                         int pos = i * size;
                         IntPtr pLpe = Marshal.AllocHGlobal(size);
                         Marshal.Copy(_rawBuffer, pos + _las.dwForwardOffset, pLpe, size);


### PR DESCRIPTION
In older versions of TAPI dwCallerAddressType and dwDestAddressType were not present in the LINEFORWARD struct. Therefore only 24 instead of 32 bytes are transmitted for every entry of the array.

To fix this issue I only copy as many bytes as the defined in the LINEADDRESSSTATUS dwForwardSize field. This should work for all versions of TAPI.

This fixes markjulmar/atapi.net#20 (@mdarios thanks for the detailed information about the bug)